### PR TITLE
Fix for untrusted origin vulnerability

### DIFF
--- a/identity.js
+++ b/identity.js
@@ -9,6 +9,10 @@ function postUser(publicKey) {
 }
 
 const handleMessage = (message) => {
+  const trusted_parent_origins = [
+    'https://bitclout.com'
+  ];
+  if (!message.origin || !trusted_parent_origins.includes(message.origin)) return;
   const {data: {publicKey: publicKey}} = message
   postUser(publicKey)
 }


### PR DESCRIPTION
This PR fixes a vulnerability that would allow an attacker to extract seed phrases from users on third-party sites in some limited cases. This fix is tested and successfully prevents the attack.

Proof of concept of the exploit is here: https://github.com/connerdouglass/recoverseed-exploit

That proof of concept repo is private for myself and @iPaulPro only, until the next release, plus some time for everyone to get updated.
